### PR TITLE
Force imageio < 2.22.2; newer versions read tiff sequences into 3D array

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -11,4 +11,4 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ package:
 source:
     url: https://github.com/schuetzgroup/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
     sha256: {{ hash }}
+    patches:
+        - test_tolerance.patch
 
 build:
     number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     sha256: {{ hash }}
 
 build:
-    number: 0
+    number: 1
     script: "{{ PYTHON }} -m pip install . --no-deps -vv"
     noarch: python
 
@@ -30,7 +30,7 @@ requirements:
         - pytables
         - opencv
         - pyyaml
-        - imageio
+        - imageio <2.22.2,>=2.18
         - numba
         - qtpy >=1.1
         - matplotlib-base

--- a/recipe/test_tolerance.patch
+++ b/recipe/test_tolerance.patch
@@ -1,0 +1,15 @@
+diff --git a/tests/daostorm_3d/test_fit.py b/tests/daostorm_3d/test_fit.py
+index e086194..da366a2 100644
+--- a/tests/daostorm_3d/test_fit.py
++++ b/tests/daostorm_3d/test_fit.py
+@@ -220,8 +220,8 @@ class FitterTest(unittest.TestCase):
+         f = fit_impl.FitterZ(self.z_sim_img, self.z_sim_local_max,
+                              self.z_params, 1e-6)
+         f.iterate()
+-        np.testing.assert_allclose(f.peaks, orig["peaks"])
+-        np.testing.assert_allclose(f.residual, orig["residual"])
++        np.testing.assert_allclose(f.peaks, orig["peaks"], atol=1e-6)
++        np.testing.assert_allclose(f.residual, orig["residual"], atol=1e-6)
+ 
+     def test_fit_z_sim(self):
+         # Produced by a test run of this implementation. Differs from


### PR DESCRIPTION
Also force >= 2.18 since conda would install ancient 2.3 if there was no lower boundary.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
